### PR TITLE
Fix Linux Permissions Issue

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,8 @@ RUN groupadd --gid $USER_GID $USERNAME \
 
 ENV SHELL=/bin/bash
 
-RUN mkdir -p /racerbot_ws && chown -R $USERNAME:$USERNAME /racerbot_ws
+RUN mkdir -p /racerbot_ws/log /racerbot_ws/build /racerbot_ws/install /racerbot_ws/src \
+    && chown -R $USERNAME:$USERNAME /racerbot_ws
 
 USER $USERNAME
 WORKDIR /racerbot_ws

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If you have already built your container just run: `docker start -ai racerbot`
 5. Update dependencies:
     ```bash
     cd /racerbot_ws
-    apt update && apt upgrade
+    sudo apt update && sudo apt upgrade -y
     rosdep update
     rosdep install --from-paths src --ignore-src -r -y
     ```

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ If you have already built your container just run: `docker start -ai racerbot`
 5. Update dependencies:
     ```bash
     cd /racerbot_ws
+    apt update && apt upgrade
     rosdep update
     rosdep install --from-paths src --ignore-src -r -y
     ```


### PR DESCRIPTION
Essentially what the issue was is that when `chown -R /racerbot_ws` runs in the Dockerfile, there are no folders to change ownership of. This is due to the fact that Docker doesn't know about the mounted volumes when the image is being built, only when the image is run. Commands in the Dockerfile are only ran at image build time

Now the Dockerfile creates those folders beforehand which allows `chown -R /racerbot_ws` to actually change the ownership and thus removing all the permission errors

I also added `sudo apt update && sudo apt upgrade -y` to the README just to make sure everything in the container is up to date as I was running into some issues with missing packages beforehand.