### PR TITLE
added commands to enable ROS2 testing repo

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,6 +14,11 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
+# Enable the ROS2 Testing Repo for the stupid ros-humble-foxglove-bridge package
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2-testing/ubuntu jammy main" | tee /etc/apt/sources.list.d/ros2-testing.list
+RUN apt update
+
 ENV SHELL=/bin/bash
 
 RUN mkdir -p /racerbot_ws/log /racerbot_ws/build /racerbot_ws/install /racerbot_ws/src \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
-# Enable the ROS2 Testing Repo for the stupid ros-humble-foxglove-bridge package
+# Enable the ROS2 Testing Repo for the ros-humble-foxglove-bridge package
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2-testing/ubuntu jammy main" | tee /etc/apt/sources.list.d/ros2-testing.list
 RUN apt update


### PR DESCRIPTION
I tested it multiple times and we can indeed install ros-humble-foxglove-bridge now. 

For some reason it is in the testing repository and not the main repository; I'm not sure why exactly but might be something we could look into later if it becomes an issue.

For now it does indeed work and on amd64 as well.
<img width="744" height="93" alt="image" src="https://github.com/user-attachments/assets/27dea485-9b28-4afa-b5aa-67f8c3207c19" />
